### PR TITLE
config: add chrome upgrade rules for Samsung S22 Ultra (SMX123) and S21 (SMB123) on Android 14

### DIFF
--- a/chrome_config.json
+++ b/chrome_config.json
@@ -23,6 +23,19 @@
           "version": "145.0.123",
           "variant": "abc"
         }
+      },
+      {
+        "id": "chrome_smb123_android14",
+        "conditions": {
+          "device_model": "SMB123",
+          "os_version": {
+            "eq": "14"
+          }
+        },
+        "action": {
+          "version": "145.0.123",
+          "variant": "abc"
+        }
       }
     ]
   },
@@ -50,6 +63,19 @@
           "version": "145.0.234",
           "variant": "bcd"
         }
+      },
+      {
+        "id": "webview_smb123_android14",
+        "conditions": {
+          "device_model": "SMB123",
+          "os_version": {
+            "eq": "14"
+          }
+        },
+        "action": {
+          "version": "145.0.234",
+          "variant": "bcd"
+        }
       }
     ]
   },
@@ -69,6 +95,19 @@
         "id": "trichrome_smx123_android14",
         "conditions": {
           "device_model": "SMX123",
+          "os_version": {
+            "eq": "14"
+          }
+        },
+        "action": {
+          "version": "145.0.345",
+          "variant": "cde"
+        }
+      },
+      {
+        "id": "trichrome_smb123_android14",
+        "conditions": {
+          "device_model": "SMB123",
           "os_version": {
             "eq": "14"
           }


### PR DESCRIPTION
### Summary

This PR introduces new browser upgrade rules for Samsung S22 Ultra (model SMX123) and Samsung S21 (model SMB123) running Android 14. The changes include:

- **Chrome**: Upgraded to version `145.0.123` with variant `abc`.
- **Webview**: Upgraded to version `145.0.234` with variant `bcd`.
- **Trichrome**: Upgraded to version `145.0.345` with variant `cde`.

### Rule Details

#### Samsung S22 Ultra (SMX123)

##### Chrome
- **Rule ID**: `chrome_smx123_android14`
- **Conditions**:
  - `device_model`: `SMX123`
  - `os_version`: `eq 14`
- **Action**:
  - `version`: `145.0.123`
  - `variant`: `abc`

##### Webview
- **Rule ID**: `webview_smx123_android14`
- **Conditions**:
  - `device_model`: `SMX123`
  - `os_version`: `eq 14`
- **Action**:
  - `version`: `145.0.234`
  - `variant`: `bcd`

##### Trichrome
- **Rule ID**: `trichrome_smx123_android14`
- **Conditions**:
  - `device_model`: `SMX123`
  - `os_version`: `eq 14`
- **Action**:
  - `version`: `145.0.345`
  - `variant`: `cde`

#### Samsung S21 (SMB123)

##### Chrome
- **Rule ID**: `chrome_smb123_android14`
- **Conditions**:
  - `device_model`: `SMB123`
  - `os_version`: `eq 14`
- **Action**:
  - `version`: `145.0.123`
  - `variant`: `abc`

##### Webview
- **Rule ID**: `webview_smb123_android14`
- **Conditions**:
  - `device_model`: `SMB123`
  - `os_version`: `eq 14`
- **Action**:
  - `version`: `145.0.234`
  - `variant`: `bcd`

##### Trichrome
- **Rule ID**: `trichrome_smb123_android14`
- **Conditions**:
  - `device_model`: `SMB123`
  - `os_version`: `eq 14`
- **Action**:
  - `version`: `145.0.345`
  - `variant`: `cde`

### Validation
- JSON validation passed.
- Local sanity check executed successfully.

### Commit Messages
- `config: add chrome upgrade rule chrome_smx123_android14 for device_model SMX123 and os_version eq 14`
- `config: add chrome upgrade rule chrome_smb123_android14 for device_model SMB123 and os_version eq 14`