### PR TITLE
config: add chrome upgrade rule chrome_smb123_android14-v145

### DIFF
--- a/chrome_config.json
+++ b/chrome_config.json
@@ -10,6 +10,17 @@
           "version": "141.0.123",
           "variant": "abc"
         }
+      },
+      {
+        "id": "chrome_smb123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMB123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.123",
+          "variant": "abc"
+        }
       }
     ]
   },
@@ -24,6 +35,17 @@
           "version": "141.0.234",
           "variant": "bcd"
         }
+      },
+      {
+        "id": "webview_smb123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMB123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.234",
+          "variant": "bcd"
+        }
       }
     ]
   },
@@ -36,6 +58,17 @@
         },
         "action": {
           "version": "141.0.345",
+          "variant": "cde"
+        }
+      },
+      {
+        "id": "trichrome_smb123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMB123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.345",
           "variant": "cde"
         }
       }


### PR DESCRIPTION
### Summary

This PR introduces a new browser upgrade rule for Chrome, WebView, and Trichrome targeting the Samsung S21 device with the following specifications:

#### Rule Details:
- **Device Model**: SMB123
- **OS Version**: 14

#### Actions:
- **Chrome**: Version `145.0.123`, Variant `abc`
- **WebView**: Version `145.0.234`, Variant `bcd`
- **Trichrome**: Version `145.0.345`, Variant `cde`

#### Changes:
- File updated: `chrome_config.json`
- Rule ID: `chrome_smb123_android14-v145`

### Validation:
- JSON validated successfully.
- Local sanity check passed.

### Notes:
This rule ensures compatibility and upgrades for the specified device and OS version.