### PR TITLE
config: add chrome upgrade rules for Samsung S21 and S22

### DIFF
--- a/chrome_config.json
+++ b/chrome_config.json
@@ -21,6 +21,17 @@
           "version": "145.0.123",
           "variant": "abc"
         }
+      },
+      {
+        "id": "chrome_smx123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMX123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.123",
+          "variant": "abc"
+        }
       }
     ]
   },
@@ -46,6 +57,17 @@
           "version": "145.0.234",
           "variant": "bcd"
         }
+      },
+      {
+        "id": "webview_smx123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMX123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.234",
+          "variant": "bcd"
+        }
       }
     ]
   },
@@ -65,6 +87,17 @@
         "id": "trichrome_smb123_android14-v145",
         "conditions": {
           "device_model": { "in": ["SMB123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.345",
+          "variant": "cde"
+        }
+      },
+      {
+        "id": "trichrome_smx123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMX123"] },
           "os_version": { "eq": "14" }
         },
         "action": {


### PR DESCRIPTION
### Summary

This PR introduces new browser upgrade rules for Samsung S21 and S22 with the following details:

#### Chrome
- **Rule ID**: `chrome_smb123_android14-v145`
- **Conditions**:
  - `device_model`: `SMB123`
  - `os_version`: `14`
- **Action**:
  - `version`: `145.0.123`
  - `variant`: `abc`

- **Rule ID**: `chrome_smx123_android14-v145`
- **Conditions**:
  - `device_model`: `SMX123`
  - `os_version`: `14`
- **Action**:
  - `version`: `145.0.123`
  - `variant`: `abc`

#### Webview
- **Rule ID**: `webview_smb123_android14-v145`
- **Conditions**:
  - `device_model`: `SMB123`
  - `os_version`: `14`
- **Action**:
  - `version`: `145.0.234`
  - `variant`: `bcd`

- **Rule ID**: `webview_smx123_android14-v145`
- **Conditions**:
  - `device_model`: `SMX123`
  - `os_version`: `14`
- **Action**:
  - `version`: `145.0.234`
  - `variant`: `bcd`

#### Trichrome
- **Rule ID**: `trichrome_smb123_android14-v145`
- **Conditions**:
  - `device_model`: `SMB123`
  - `os_version`: `14`
- **Action**:
  - `version`: `145.0.345`
  - `variant`: `cde`

- **Rule ID**: `trichrome_smx123_android14-v145`
- **Conditions**:
  - `device_model`: `SMX123`
  - `os_version`: `14`
- **Action**:
  - `version`: `145.0.345`
  - `variant`: `cde`

### Validation
- JSON validation passed.
- Local sanity check executed successfully.