### PR TITLE
config: add chrome upgrade rule for Samsung S21 with os version 14

### DIFF
--- a/chrome_config.json
+++ b/chrome_config.json
@@ -10,6 +10,17 @@
           "version": "141.0.123",
           "variant": "abc"
         }
+      },
+      {
+        "id": "chrome_smb123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMB123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.123",
+          "variant": "abc"
+        }
       }
     ]
   },
@@ -24,6 +35,17 @@
           "version": "141.0.234",
           "variant": "bcd"
         }
+      },
+      {
+        "id": "webview_smb123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMB123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.234",
+          "variant": "bcd"
+        }
       }
     ]
   },
@@ -36,6 +58,17 @@
         },
         "action": {
           "version": "141.0.345",
+          "variant": "cde"
+        }
+      },
+      {
+        "id": "trichrome_smb123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMB123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.345",
           "variant": "cde"
         }
       }


### PR DESCRIPTION
### Summary

This PR introduces new browser upgrade rules for Samsung S21 with the following specifications:

#### Chrome:
- **Version**: 145.0.123
- **Variant**: abc
- **Conditions**:
  - `device_model`: SMB123
  - `os_version`: 14

#### Webview:
- **Version**: 145.0.234
- **Variant**: bcd
- **Conditions**:
  - `device_model`: SMB123
  - `os_version`: 14

#### Trichrome:
- **Version**: 145.0.345
- **Variant**: cde
- **Conditions**:
  - `device_model`: SMB123
  - `os_version`: 14

### Validation
- JSON structure validated.
- Local sanity check passed using `browser_upgrade_manager.rb`.

### Commit
- `config: add chrome upgrade rule for Samsung S21 with os version 14`