### PR TITLE
config: add chrome upgrade rule for Samsung devices with os version 14

### DIFF
--- a/chrome_config.json
+++ b/chrome_config.json
@@ -12,20 +12,9 @@
         }
       },
       {
-        "id": "chrome_smb123_android14-v145",
+        "id": "chrome_samsung_android14-v145",
         "conditions": {
-          "device_model": { "in": ["SMB123"] },
-          "os_version": { "eq": "14" }
-        },
-        "action": {
-          "version": "145.0.123",
-          "variant": "abc"
-        }
-      },
-      {
-        "id": "chrome_smx123_android14-v145",
-        "conditions": {
-          "device_model": { "in": ["SMX123"] },
+          "manufacturer": { "in": ["Samsung"] },
           "os_version": { "eq": "14" }
         },
         "action": {
@@ -48,20 +37,9 @@
         }
       },
       {
-        "id": "webview_smb123_android14-v145",
+        "id": "webview_samsung_android14-v145",
         "conditions": {
-          "device_model": { "in": ["SMB123"] },
-          "os_version": { "eq": "14" }
-        },
-        "action": {
-          "version": "145.0.234",
-          "variant": "bcd"
-        }
-      },
-      {
-        "id": "webview_smx123_android14-v145",
-        "conditions": {
-          "device_model": { "in": ["SMX123"] },
+          "manufacturer": { "in": ["Samsung"] },
           "os_version": { "eq": "14" }
         },
         "action": {
@@ -84,20 +62,9 @@
         }
       },
       {
-        "id": "trichrome_smb123_android14-v145",
+        "id": "trichrome_samsung_android14-v145",
         "conditions": {
-          "device_model": { "in": ["SMB123"] },
-          "os_version": { "eq": "14" }
-        },
-        "action": {
-          "version": "145.0.345",
-          "variant": "cde"
-        }
-      },
-      {
-        "id": "trichrome_smx123_android14-v145",
-        "conditions": {
-          "device_model": { "in": ["SMX123"] },
+          "manufacturer": { "in": ["Samsung"] },
           "os_version": { "eq": "14" }
         },
         "action": {

--- a/chrome_config.json
+++ b/chrome_config.json
@@ -21,6 +21,17 @@
           "version": "145.0.123",
           "variant": "abc"
         }
+      },
+      {
+        "id": "chrome_smx123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMX123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.123",
+          "variant": "abc"
+        }
       }
     ]
   },
@@ -46,6 +57,17 @@
           "version": "145.0.234",
           "variant": "bcd"
         }
+      },
+      {
+        "id": "webview_smx123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMX123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.234",
+          "variant": "bcd"
+        }
       }
     ]
   },
@@ -65,6 +87,17 @@
         "id": "trichrome_smb123_android14-v145",
         "conditions": {
           "device_model": { "in": ["SMB123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.345",
+          "variant": "cde"
+        }
+      },
+      {
+        "id": "trichrome_smx123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMX123"] },
           "os_version": { "eq": "14" }
         },
         "action": {

--- a/chrome_config.json
+++ b/chrome_config.json
@@ -10,6 +10,17 @@
           "version": "141.0.123",
           "variant": "abc"
         }
+      },
+      {
+        "id": "chrome_smb123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMB123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.123",
+          "variant": "abc"
+        }
       }
     ]
   },
@@ -24,6 +35,17 @@
           "version": "141.0.234",
           "variant": "bcd"
         }
+      },
+      {
+        "id": "webview_smb123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMB123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.234",
+          "variant": "bcd"
+        }
       }
     ]
   },
@@ -36,6 +58,17 @@
         },
         "action": {
           "version": "141.0.345",
+          "variant": "cde"
+        }
+      },
+      {
+        "id": "trichrome_smb123_android14-v145",
+        "conditions": {
+          "device_model": { "in": ["SMB123"] },
+          "os_version": { "eq": "14" }
+        },
+        "action": {
+          "version": "145.0.345",
           "variant": "cde"
         }
       }


### PR DESCRIPTION
### Summary

This PR introduces new browser upgrade rules for all Samsung devices with the following specifications:

#### Chrome:
- **Version**: 145.0.123
- **Variant**: abc
- **Conditions**:
  - `manufacturer`: Samsung
  - `os_version`: 14

#### Webview:
- **Version**: 145.0.234
- **Variant**: bcd
- **Conditions**:
  - `manufacturer`: Samsung
  - `os_version`: 14

#### Trichrome:
- **Version**: 145.0.345
- **Variant**: cde
- **Conditions**:
  - `manufacturer`: Samsung
  - `os_version`: 14

### Validation
- JSON structure validated.
- Local sanity check passed using `browser_upgrade_manager.rb`.

### Commit
- `config: add chrome upgrade rule for Samsung devices with os version 14`